### PR TITLE
Allow aliases in Select statements

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,72 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+  schedule:
+    - cron: '24 23 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'java', 'javascript' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        
+        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+        
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
+    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+    # - run: |
+    #   echo "Run, Build Application using script"
+    #   ./location_of_script_within_repo/buildscript.sh
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/javasource/databaseconnector/impl/ResultSetIterator.java
+++ b/javasource/databaseconnector/impl/ResultSetIterator.java
@@ -46,7 +46,7 @@ public class ResultSetIterator implements Iterator<ResultSet> {
     final String columnName;
 
     try {
-      columnName = resultSet.getMetaData().getColumnName(index);
+      columnName = resultSet.getMetaData().getColumnLabel(index);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
This is based off a comment in the app store be Wouter van Maasakker - RWS. It allows the use of an alias in a select statement (Select id as myId from ...)

It works well for me, but I can't run the tests.

Here's the comment: In ResultSetIterator.java on line 49 you will get the name from getColumnName. This works perfectly if your domainmodel exactly meets the database model. But in many cases the name of the attributes are different or the case is not equal. This results in a horrifying Null pointer exception.

In your queries you want to use the AS statement eq. SELECT name AS FirstName FROM employees.

If you want to change this you have to alter the ResultSetIterator on row 49 from:
columnName = resultSet.getMetaData().getColumnName(index);
to
columnName = resultSet.getMetaData().getColumnLabel(index);